### PR TITLE
Fix DataInitializer constructors

### DIFF
--- a/src/main/java/com/fifastreet/fifastreet/init/DataInitializer.java
+++ b/src/main/java/com/fifastreet/fifastreet/init/DataInitializer.java
@@ -32,20 +32,37 @@ public class DataInitializer implements CommandLineRunner{
         // Initialize locations, teams, and players here
         for (int i = 0; i < 10; i++) {
             String locationName = "Location " + (i + 1);
-            var location = new com.fifastreet.fifastreet.model.Location(locationName);
+            var location = new com.fifastreet.fifastreet.model.Location();
+            location.setName(locationName);
             locationRepository.save(location);
 
             for (int j = 0; j < 5; j++) {
                 String teamName = "Team " + (j + 1) + " in " + locationName;
-                var team = new com.fifastreet.fifastreet.model.Team(teamName, location);
+                var team = new com.fifastreet.fifastreet.model.Team();
+                team.setName(teamName);
+                team.setRegion(locationName);
+                team.setLocation(location);
                 teamRepository.save(team);
 
                 for (int k = 0; k < 11; k++) {
                     String playerName = "Player " + (k + 1) + " in " + teamName;
-                    var player = new com.fifastreet.fifastreet.model.Player(playerName, randomPosition(), team);
+                    var player = new com.fifastreet.fifastreet.model.Player();
+                    player.setName(playerName);
+                    player.setPosition(randomPosition());
+                    player.setStrength(randomStrength());
+                    player.setTeam(team);
                     playerRepository.save(player);
                 }
             }
         }
+    }
+
+    private String randomPosition() {
+        String[] positions = { "Torwart", "Verteidiger", "Mittelfeld", "Stürmer" };
+        return positions[random.nextInt(positions.length)];
+    }
+
+    private double randomStrength() {
+        return 50 + random.nextInt(51); // 50 - 100
     }
 }

--- a/src/main/java/com/fifastreet/fifastreet/init/DataInitializer.java
+++ b/src/main/java/com/fifastreet/fifastreet/init/DataInitializer.java
@@ -36,7 +36,7 @@ public class DataInitializer implements CommandLineRunner{
             location.setName(locationName);
             locationRepository.save(location);
 
-            for (int j = 0; j < 5; j++) {
+            for (int j = 0; j < 4; j++) {
                 String teamName = "Team " + (j + 1) + " in " + locationName;
                 var team = new com.fifastreet.fifastreet.model.Team();
                 team.setName(teamName);
@@ -48,7 +48,12 @@ public class DataInitializer implements CommandLineRunner{
                     String playerName = "Player " + (k + 1) + " in " + teamName;
                     var player = new com.fifastreet.fifastreet.model.Player();
                     player.setName(playerName);
-                    player.setPosition(randomPosition());
+                    // Ensure at least one goalkeeper per team
+                    if (k == 0) {
+                        player.setPosition("Torwart");
+                    } else {
+                        player.setPosition(randomPosition());
+                    }
                     player.setStrength(randomStrength());
                     player.setTeam(team);
                     playerRepository.save(player);


### PR DESCRIPTION
## Summary
- use setters to initialize JPA entities
- add random position and strength helpers

## Testing
- `./mvnw -q test` *(fails: cannot fetch Maven)*

------
https://chatgpt.com/codex/tasks/task_e_683fcbfdf96c832abe255f803881cdd6